### PR TITLE
fix: correct inconsistencies of header and footer

### DIFF
--- a/app/site-config/header.tsx
+++ b/app/site-config/header.tsx
@@ -25,7 +25,7 @@ const MOCK_NAV_ITEM_WITH_DROPDOWN_2 = [
 ];
 const MOCK_NAV_ITEM_WITH_DROPDOWN_3 = [
   {
-    label: "Resources and Learning",
+    label: "Resources & Learning",
     subItems: [
       { label: "Training", href: "/training" },
       { label: "News, Event & Stories", href: "/news-event-stories" },
@@ -41,7 +41,7 @@ export const MOCK_HEADER_PROPS: HeaderProps = {
     url: "/",
   },
   navItems: [
-    { label: "About us", href: "/about-us" },
+    { label: "About us", href: "/about" },
     ...MOCK_NAV_ITEM_WITH_DROPDOWN_1,
     ...MOCK_NAV_ITEM_WITH_DROPDOWN_2,
     ...MOCK_NAV_ITEM_WITH_DROPDOWN_3,

--- a/app/site-config/home-card-hero.tsx
+++ b/app/site-config/home-card-hero.tsx
@@ -23,7 +23,7 @@ const MOCK_FEATURE_CTACARDS_PROPS = [
   {
     title: "Build Resilience",
     description: "Safeguard communities for enduring impact.",
-    url: "/resilience",
+    url: "/build-resilience",
     accentColor: "#1d9950",
   },
 ];


### PR DESCRIPTION
Quick PR for fixing inconsistencies in header and footer:

- `About Us` href: `/about-us` → `/about` (matches footer)
- Nav label: `Resources and Learning` → `Resources & Learning` (matches footer)
- Hero CTA `Build Resilience`: `/resilience` → `/build-resilience` (matches header dropdown)

