### PR TITLE
fix: cleanup font dependencies, etc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
   "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "[scss]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "prepare": "lefthook install"
   },
   "dependencies": {
-    "@fontsource-variable/inter": "^5.2.8",
-    "@fontsource/dm-mono": "^5.2.7",
     "@tanstack/react-query": "^5.99.0",
     "@teamimpact/veda-ui-blocks": "0.1.0-beta.7",
     "@trussworks/react-uswds": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@fontsource-variable/inter':
-        specifier: ^5.2.8
-        version: 5.2.8
-      '@fontsource/dm-mono':
-        specifier: ^5.2.7
-        version: 5.2.7
       '@tanstack/react-query':
         specifier: ^5.99.0
         version: 5.100.9(react@19.2.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-onlyBuiltDependencies:
-  - tinacms-portal-monorepo


### PR DESCRIPTION
* removes font dependencies as these are bundled with veda-ui-blocks
* removes pnpm workspace as this is not a monorepo
* adds biome as explicit formatter in vscode for ts and react (my vscode was defaulting to prettier 🤷‍♀️)