### PR TITLE
feat:Add reusable CardCarouselSection component

### DIFF
--- a/app/components/CardCarouselSection.tsx
+++ b/app/components/CardCarouselSection.tsx
@@ -1,8 +1,7 @@
 import { Card, type CardSimpleProps } from "@teamimpact/veda-ui-blocks";
 import type { ReactNode } from "react";
 import { SectionHeading } from "./SectionHeading";
-
-type CardWithId = CardSimpleProps & { id: string };
+import type { CardWithId } from "./types";
 
 type CardCarouselSection = {
   sectionHeading?: ReactNode;

--- a/app/components/CardCarouselSection.tsx
+++ b/app/components/CardCarouselSection.tsx
@@ -1,0 +1,36 @@
+import { Card, type CardSimpleProps } from "@teamimpact/veda-ui-blocks";
+import type { ReactNode } from "react";
+import { SectionHeading } from "./SectionHeading";
+
+type CardWithId = CardSimpleProps & { id: string };
+
+type CardCarouselSection = {
+  sectionHeading?: ReactNode;
+  cards: CardWithId[];
+};
+
+export const CardCarouselSection = ({ sectionHeading, cards }: CardCarouselSection) => {
+  return (
+    <section className="padding-y-7">
+      <div className="grid-container">
+        {sectionHeading && (
+          <SectionHeading className="margin-bottom-4">{sectionHeading}</SectionHeading>
+        )}
+      </div>
+      <div className="grid-container">
+        <div className="grid-row grid-gap-2 margin-bottom-neg-2">
+          {cards.map((card) => {
+            return (
+              <div
+                key={card.id}
+                className="grid-col-12 tablet:grid-col-6 desktop:grid-col-6 margin-bottom-2"
+              >
+                <Card {...card} />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/app/components/index.tsx
+++ b/app/components/index.tsx
@@ -1,3 +1,4 @@
+export { CardCarouselSection } from "./CardCarouselSection";
 export { HeaderWithCurrentPath } from "./HeaderWithCurrentPath";
 export { PageStatus } from "./PageStatus";
 export { Section } from "./Section";

--- a/app/components/types.tsx
+++ b/app/components/types.tsx
@@ -1,0 +1,3 @@
+import type { CardSimpleProps } from "@teamimpact/veda-ui-blocks";
+
+export type CardWithId = CardSimpleProps & { id: string };

--- a/app/site-config/news-events.tsx
+++ b/app/site-config/news-events.tsx
@@ -1,8 +1,7 @@
 import type { CardSimpleProps } from "@teamimpact/veda-ui-blocks";
 import { Tag } from "@teamimpact/veda-ui-blocks";
 import Image from "next/image";
-
-type CardWithId = CardSimpleProps & { id: string };
+import type { CardWithId } from "../components/types";
 
 export const MOCK_CARD_NEWS_EVENTS_FEATURED: CardWithId = {
   id: "card-news-featured",

--- a/app/site-config/resources-learning.tsx
+++ b/app/site-config/resources-learning.tsx
@@ -1,8 +1,7 @@
 import type { CardSimpleProps } from "@teamimpact/veda-ui-blocks";
 import { Tag } from "@teamimpact/veda-ui-blocks";
 import Image from "next/image";
-
-type CardWithId = CardSimpleProps & { id: string };
+import type { CardWithId } from "../components/types";
 
 export const MOCK_CARD_RESOURCES_LEARNING_PREPARE: CardWithId = {
   id: "card-prepare",


### PR DESCRIPTION
## Summary

Creates a shared `CardCarouselSection` component to replace ad-hoc card grid layouts across the site, and consolidates the `CardWithId` type into a shared location.

## Changes

### New: `CardCarouselSection` component

- Renders a responsive card grid section using the USWDS grid system
- Accepts an optional `sectionHeading` and a list of `CardWithId` items
- Cards display in a 2-column layout on tablet/desktop, single column on mobile
- Composes the existing `SectionHeading` component and `Card` from `veda-ui-blocks`