### PR TITLE
refactor: rename TrainingBlock to ContentBlockRenderer

### DIFF
--- a/app/components/ContentBlockRenderer.tsx
+++ b/app/components/ContentBlockRenderer.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { ImageComparison, Section, SectionHeading } from "@/app/components";
 import type { ContentBlock } from "@/app/site-config/types";
 
-export const TrainingBlock = ({ block }: { block: ContentBlock }) => {
+export const ContentBlockRenderer = ({ block }: { block: ContentBlock }) => {
   switch (block.type) {
     case "text":
       return (

--- a/app/components/index.tsx
+++ b/app/components/index.tsx
@@ -1,3 +1,4 @@
+export { ContentBlockRenderer } from "./ContentBlockRenderer";
 export { HeaderWithCurrentPath } from "./HeaderWithCurrentPath";
 export { ImageComparison } from "./ImageComparison";
 export { PageMasthead } from "./PageMasthead";

--- a/app/training/[id]/page.tsx
+++ b/app/training/[id]/page.tsx
@@ -2,9 +2,8 @@ import { Card, Tag } from "@teamimpact/veda-ui-blocks";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 
-import { Section, ThemeTag } from "@/app/components";
+import { ContentBlockRenderer, Section, ThemeTag } from "@/app/components";
 import { TRAININGS } from "@/app/site-config/training";
-import { TrainingBlock } from "@/app/training/TrainingBlock";
 
 export default async function TrainingItemPage(props: PageProps<"/training/[id]">) {
   const { id } = await props.params;
@@ -83,7 +82,7 @@ export default async function TrainingItemPage(props: PageProps<"/training/[id]"
           <div className="grid-col-12 desktop:grid-col-9 margin-top-neg-7">
             {training.body.map((block, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: static content blocks, never reorder
-              <TrainingBlock key={i} block={block} />
+              <ContentBlockRenderer key={i} block={block} />
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Rename and move `TrainingBlock` component to shared location as `ContentBlockRenderer`
- Update `training/[id]/page.tsx` to use the renamed component
- Export `ContentBlockRenderer` from components index

## Context
The `TrainingBlock` component is already generic and only depends on the shared `ContentBlock` type. Moving it to a shared location makes it available for reuse across other content types (stories, events, news, datasets).

## Changes
- Move: `app/training/TrainingBlock.tsx` → `app/components/ContentBlockRenderer.tsx`
- Update: `app/training/[id]/page.tsx` import and usage
- Add: Export in `app/components/index.tsx`

Relates to #116