### PR TITLE
feat: refine data gallery card layout and tag rendering

### DIFF
--- a/app/data-gallery/page.tsx
+++ b/app/data-gallery/page.tsx
@@ -1,7 +1,7 @@
 import { CardDetailed } from "@teamimpact/veda-ui-blocks";
 import { PageMasthead, Section } from "@/app/components";
 import { DATA_GALLERY_CARD_MASTHEAD } from "@/app/site-config/dataset/data-gallery-card-masthead";
-import { makeCardDetailedImageLeftProps } from "../site-config/content.helpers";
+import { makeDatasetCardProps } from "../site-config/content.helpers";
 import { DATASETS } from "../site-config/dataset";
 
 export default function DataGalleryPage() {
@@ -11,13 +11,9 @@ export default function DataGalleryPage() {
       <Section>
         <div className="grid-row grid-gap">
           {DATASETS.map(({ id, categories, themes, ...card }) => (
-            <div key={id} className="grid-col-12">
+            <div key={id} className="grid-col-12 margin-y-1 desktop:margin-y-2">
               <CardDetailed
-                {...makeCardDetailedImageLeftProps({
-                  ...card,
-                  id,
-                  tags: [...categories, ...themes],
-                })}
+                {...makeDatasetCardProps({ id, categories, themes, ...card })}
                 className="height-card-sm"
               />
             </div>

--- a/app/site-config/content.helpers.tsx
+++ b/app/site-config/content.helpers.tsx
@@ -137,6 +137,35 @@ export const makeCardDetailedImageLeftProps = ({
   ...rest,
 });
 
+export type DatasetCardPropsArgs = {
+  id: string;
+  thumbnailImage: { alt: string; src: string };
+  themes: Theme[];
+  categories: Category[];
+  url?: string;
+  [key: string]: unknown;
+};
+
+export const makeDatasetCardProps = ({
+  id,
+  thumbnailImage,
+  themes,
+  categories,
+  url,
+  contentType: _contentType,
+  ...rest
+}: DatasetCardPropsArgs): IterableItemWithId<CardDetailedProps> => ({
+  id,
+  image: <Image {...thumbnailImage} fill sizes="(max-width: 1400px) 100vw, 1400px" />,
+  imagePosition: "left",
+  tags: [...themes.map(makeThemeTag), ...categories.map(makeSimpleTag)],
+  callToAction: {
+    href: url ?? `/data-gallery/${id}`,
+    label: "view data",
+  },
+  ...rest,
+});
+
 export type CardSimplePropsArgs = {
   id: string;
   contentType: ContentType;

--- a/app/site-config/dataset/dataset__blackmarble-hd-daily-june2026.ts
+++ b/app/site-config/dataset/dataset__blackmarble-hd-daily-june2026.ts
@@ -8,7 +8,7 @@ export const DATASET__BLACKMARBLE_HD_DAILY_JUNE2026: DatasetContent = {
   description:
     "NASA Black Marble high-definition daily nighttime lights imagery captured during Hurricane Helene (September 28, 2024). Nighttime light anomalies reveal power outages and population displacement.",
   thumbnailImage: {
-    src: "/img/logo-emblem.svg",
+    src: "/img/datastory/hurricane-helene-september-2024.webp",
     alt: "Black Marble HD daily nighttime lights",
   },
   themes: ["respond", "prepare", "recover"],

--- a/app/site-config/dataset/dataset__blackmarble-june2026-composite.ts
+++ b/app/site-config/dataset/dataset__blackmarble-june2026-composite.ts
@@ -8,7 +8,7 @@ export const DATASET__BLACKMARBLE_JUNE2026_COMPOSITE: DatasetContent = {
   description:
     "NASA Black Marble monthly composite of nighttime lights for January 2024. Provides a pre-event baseline for before/after disaster comparisons.",
   thumbnailImage: {
-    src: "/img/logo-emblem.svg",
+    src: "/img/datastory/hurricane-milton-october-2024.webp",
     alt: "Black Marble monthly composite nighttime lights",
   },
   themes: ["prepare", "respond"],

--- a/app/site-config/dataset/dataset__viirs-active-fire.ts
+++ b/app/site-config/dataset/dataset__viirs-active-fire.ts
@@ -8,7 +8,7 @@ export const DATASET__VIIRS_ACTIVE_FIRE: DatasetContent = {
   description:
     "NASA VIIRS (Visible Infrared Imaging Radiometer Suite) active fire detections derived from 375m thermal anomaly data. Near real-time fire locations for situational awareness and post-event impact assessment.",
   thumbnailImage: {
-    src: "/img/logo-emblem.svg",
+    src: "/img/training/eo-pre-post-fire-monitoring.webp",
     alt: "VIIRS active fire detection",
   },
   themes: ["respond", "prepare"],


### PR DESCRIPTION
## Summary

- Add `makeDatasetCardProps` helper with correctly colored theme tags (`makeThemeTag`) and flat category tags (`makeSimpleTag`)
- Add `DatasetCardPropsArgs` named type following file convention
- Add vertical spacing between cards (`margin-y-1 desktop:margin-y-2`)
- Update dataset thumbnail images with relevant imagery

Contributes to #62. Search/filter functionality should be added in a separate PR.

## Test plan

- [ ] Visit `/data-gallery` and verify cards render with colored theme tags
- [ ] Verify card spacing matches Figma design
- [ ] Verify thumbnail images load for all three datasets