### PR TITLE
refactor: rename categories to hazards

### DIFF
--- a/app/data-gallery/page.tsx
+++ b/app/data-gallery/page.tsx
@@ -10,13 +10,13 @@ export default function DataGalleryPage() {
       <PageMasthead {...DATA_GALLERY_CARD_MASTHEAD} />
       <Section>
         <div className="grid-row grid-gap">
-          {DATASETS.map(({ id, categories, themes, ...card }) => (
+          {DATASETS.map(({ id, hazards, themes, ...card }) => (
             <div key={id} className="grid-col-12">
               <CardDetailed
                 {...makeCardDetailedImageLeftProps({
                   ...card,
                   id,
-                  tags: [...categories, ...themes],
+                  tags: [...hazards, ...themes],
                 })}
                 className="height-card-sm"
               />

--- a/app/site-config/content.helpers.tsx
+++ b/app/site-config/content.helpers.tsx
@@ -6,7 +6,7 @@ import {
 } from "@teamimpact/veda-ui-blocks";
 import Image from "next/image";
 import type { AppRoutes } from "@/.next/types/routes";
-import type { Category, ContentType, IterableItemWithId, Theme } from "./types";
+import type { ContentType, Hazard, IterableItemWithId, Theme } from "./types";
 
 const CONTENT_THEMES: Record<Theme, Record<string, unknown>> = {
   respond: {
@@ -39,7 +39,7 @@ const CONTENT_TYPES: Record<ContentType, { route: AppRoutes; label: string }> = 
   training: { route: "/training", label: "training" },
 };
 
-export const makeSimpleTag = (tag: Theme | ContentType | Category) => (
+export const makeSimpleTag = (tag: Theme | ContentType | Hazard) => (
   <Tag variant="solid" color="primary-lighter">
     {tag}
   </Tag>
@@ -89,7 +89,7 @@ export type CardDetailedPropsArgs = {
     alt: string;
     src: string;
   };
-  tags?: (Theme | ContentType | Category)[];
+  tags?: (Theme | ContentType | Hazard)[];
   url?: string;
   [key: string]: unknown;
 };
@@ -145,7 +145,7 @@ export type CardSimplePropsArgs = {
     alt: string;
     src: string;
   };
-  tag?: Theme | ContentType | Category;
+  tag?: Theme | ContentType | Hazard;
   themes?: Theme[];
   url?: string;
   [key: string]: unknown;

--- a/app/site-config/dataset/index.ts
+++ b/app/site-config/dataset/index.ts
@@ -9,7 +9,7 @@ export const DATASETS: DatasetContent[] = [
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat",
     thumbnailImage: { src: "/img/logo-emblem.svg", alt: "placeholder image" },
     themes: ["prepare"],
-    categories: ["severewx", "flood", "tropical cyclone"],
+    hazards: ["severewx", "flood", "tropical cyclone"],
     mastheadImage: {
       src: "/img/card-masthead.webp",
       alt: "",

--- a/app/site-config/datastory/datastory__hurricane-helene-september-2024.ts
+++ b/app/site-config/datastory/datastory__hurricane-helene-september-2024.ts
@@ -9,7 +9,7 @@ export const DATASTORY__HURRICANE_HELENE_SEPTEMBER_2024: DataStoryContent = {
     alt: "Nighttime satellite image of Hurricane Helene in 2024 captured by NOAA-20",
   },
   themes: [],
-  categories: [],
+  hazards: [],
   mastheadImage: {
     src: "/img/datastory/hurricane-helene-september-2024.webp",
     alt: "Nighttime satellite image of Hurricane Helene in 2024 captured by NOAA-20",

--- a/app/site-config/datastory/datastory__hurricane-milton-october-2024.ts
+++ b/app/site-config/datastory/datastory__hurricane-milton-october-2024.ts
@@ -9,7 +9,7 @@ export const DATASTORY__HURRICANE_MILTON_OCTOBER_2024: DataStoryContent = {
     alt: "Hurricane Milton in 2024 showing storm system over ocean with visible eye of the storm",
   },
   themes: [],
-  categories: [],
+  hazards: [],
   mastheadImage: {
     src: "/img/datastory/hurricane-milton-october-2024.webp",
     alt: "Hurricane Milton in 2024 showing storm system over ocean with visible eye of the storm",

--- a/app/site-config/event/event__typhoon-sinlaku-2026.tsx
+++ b/app/site-config/event/event__typhoon-sinlaku-2026.tsx
@@ -13,5 +13,5 @@ export const EVENT__TYPHOON_SINLAKU_2026: EventContent = {
     alt: "Satellite worldview imagery of Typhoon Sinlaku from April 2026",
   },
   themes: [],
-  categories: [],
+  hazards: [],
 };

--- a/app/site-config/news/news__new-disasters-portal-test-help.tsx
+++ b/app/site-config/news/news__new-disasters-portal-test-help.tsx
@@ -13,5 +13,5 @@ export const NEWS__NEW_DISASTERS_PORTAL_TEST_HELP: NewsContent = {
     alt: "NASA Disasters Portal team members at a field event",
   },
   themes: [],
-  categories: [],
+  hazards: [],
 };

--- a/app/site-config/story/story__clearing-the-way-debris-mapping.ts
+++ b/app/site-config/story/story__clearing-the-way-debris-mapping.ts
@@ -9,7 +9,7 @@ export const STORY__CLEARING_THE_WAY_DEBRIS_MAPPING: StoryContent = {
     alt: "Aerial photo showing tornado destruction with debris and damaged homes in Chattanooga, Tennessee after a tornado struck the region April 12, 2020",
   },
   themes: [],
-  categories: [],
+  hazards: [],
   mastheadImage: {
     src: "/img/story/clearing-the-way-debris-mapping.webp",
     alt: "Aerial photo showing tornado destruction with debris and damaged homes in Chattanooga, Tennessee after a tornado struck the region April 12, 2020",

--- a/app/site-config/story/story__estimating-loss-recovery.ts
+++ b/app/site-config/story/story__estimating-loss-recovery.ts
@@ -13,5 +13,5 @@ export const STORY__ESTIMATING_LOSS_RECOVERY: StoryContent = {
     alt: "Community recovery efforts in Mayfield after disaster, showing rebuilding in progress",
   },
   themes: [],
-  categories: [],
+  hazards: [],
 };

--- a/app/site-config/story/story__finding-floods.ts
+++ b/app/site-config/story/story__finding-floods.ts
@@ -13,5 +13,5 @@ export const STORY__FINDING_FLOODS: StoryContent = {
     alt: "Flooded river in Kerrville, Texas showing significant flood waters",
   },
   themes: [],
-  categories: [],
+  hazards: [],
 };

--- a/app/site-config/story/story__identifying-infrastructure-risks-hurricane.ts
+++ b/app/site-config/story/story__identifying-infrastructure-risks-hurricane.ts
@@ -9,7 +9,7 @@ export const STORY__IDENTIFYING_INFRASTRUCTURE_RISKS_HURRICANE: StoryContent = {
     alt: "Illuminated Miami, Florida skyline with a bridge reflection at night, Jan. 13, 2024",
   },
   themes: [],
-  categories: [],
+  hazards: [],
   mastheadImage: {
     src: "/img/story/identifying-infrastructure-risks-hurricane.webp",
     alt: "Illuminated Miami, Florida skyline with a bridge reflection at night, Jan. 13, 2024",

--- a/app/site-config/story/story__mapping_oil_spills_from_space.ts
+++ b/app/site-config/story/story__mapping_oil_spills_from_space.ts
@@ -9,7 +9,7 @@ export const STORY__MAPPING_OIL_SPILLS_FROM_SPACE: StoryContent = {
     alt: "An oil slick from naturally occurring oil seeps off the coast of Santa Barbara, California.",
   },
   themes: [],
-  categories: [],
+  hazards: [],
   mastheadImage: {
     src: "/img/story/mapping_oil_spills_from_space.webp",
     alt: "An oil slick from naturally occurring oil seeps off the coast of Santa Barbara, California.",

--- a/app/site-config/training/training__eo-building-exposure.ts
+++ b/app/site-config/training/training__eo-building-exposure.ts
@@ -13,7 +13,7 @@ export const TRAINING__EO_BUILDING_EXPOSURE: TrainingContent = {
   },
   date: "2026-01-15",
   themes: ["recover", "prepare", "respond", "build"],
-  categories: ["earthquake", "tropical cyclone"],
+  hazards: ["earthquake", "tropical cyclone"],
   mastheadImage: {
     src: "/img/training/eo-building-exposure.webp",
     alt: "Los Angeles building exposure map showing building risk data across the city",

--- a/app/site-config/training/training__eo-pre-post-fire-monitoring.ts
+++ b/app/site-config/training/training__eo-pre-post-fire-monitoring.ts
@@ -10,5 +10,5 @@ export const TRAINING__EO_PRE_POST_FIRE_MONITORING: TrainingContentExternal = {
   },
   url: "https://www.earthdata.nasa.gov/learn/trainings/using-earth-observations-pre-post-fire-monitoring ",
   themes: [],
-  categories: [],
+  hazards: [],
 };

--- a/app/site-config/training/training__fundamentals-remote-sensing.ts
+++ b/app/site-config/training/training__fundamentals-remote-sensing.ts
@@ -10,5 +10,5 @@ export const TRAINING__FUNDAMENTALS_REMOTE_SENSING: TrainingContentExternal = {
   },
   url: "https://www.earthdata.nasa.gov/learn/trainings/fundamentals-remote-sensing",
   themes: ["prepare"],
-  categories: [],
+  hazards: [],
 };

--- a/app/site-config/training/training__introduction-to-sar.ts
+++ b/app/site-config/training/training__introduction-to-sar.ts
@@ -10,5 +10,5 @@ export const TRAINING__INTRODUCTION_TO_SAR: TrainingContentExternal = {
   },
   url: "https://www.earthdata.nasa.gov/learn/trainings/introduction-synthetic-aperture-radar-sar-its-applications",
   themes: ["prepare"],
-  categories: [],
+  hazards: [],
 };

--- a/app/site-config/training/training__lifelines-wildfire-workflow.tsx
+++ b/app/site-config/training/training__lifelines-wildfire-workflow.tsx
@@ -14,7 +14,7 @@ export const TRAINING__LIFELINES_WILDFIRE_WORKFLOW: TrainingContent = {
   },
   date: "2026-01-15",
   themes: ["respond", "prepare"],
-  categories: ["fire"],
+  hazards: ["fire"],
   mastheadImage: {
     src: "/img/training/lifelines-wildfire-workflow.webp",
     alt: "Satellite-derived wildfire data workflow showing fire detections and risk zones",

--- a/app/site-config/types.ts
+++ b/app/site-config/types.ts
@@ -4,7 +4,7 @@ export type IterableItemWithId<T> = T & { id: string };
 
 export type Theme = "respond" | "build" | "prepare" | "recover";
 
-export type Category = "severewx" | "fire" | "heat" | "flood" | "tropical cyclone" | "earthquake";
+export type Hazard = "severewx" | "fire" | "heat" | "flood" | "tropical cyclone" | "earthquake";
 
 export type ContentBlock =
   | { type: "text"; heading?: string; headingLevel?: "h2" | "h3" | "h4"; paragraphs: ReactNode[] }
@@ -39,7 +39,7 @@ export type MinimumCardContent = {
     alt: string;
   };
   themes: Theme[];
-  categories: Category[];
+  hazards: Hazard[];
   description?: string;
 };
 

--- a/app/training/[id]/page.tsx
+++ b/app/training/[id]/page.tsx
@@ -61,14 +61,14 @@ export default async function TrainingItemPage(props: PageProps<"/training/[id]"
                 </div>
               )}
 
-              {training.categories.length > 0 && (
+              {training.hazards.length > 0 && (
                 <div className="margin-bottom-3">
                   <p className="text-bold font-body-sm margin-top-0 margin-bottom-2">Hazard</p>
                   <div className="display-flex flex-wrap">
-                    {training.categories.map((category) => (
-                      <div key={category} className="margin-right-1 margin-bottom-1">
+                    {training.hazards.map((hazard) => (
+                      <div key={hazard} className="margin-right-1 margin-bottom-1">
                         <Tag color="primary-lighter" textColor="primary-dark">
-                          {category}
+                          {hazard}
                         </Tag>
                       </div>
                     ))}

--- a/app/training/page.tsx
+++ b/app/training/page.tsx
@@ -10,7 +10,7 @@ export default function TrainingCollectionPage() {
       <PageMasthead {...PAGE__CARD_MASTHEAD} />
       <Section>
         <div className="grid-row grid-gap">
-          {[...TRAININGS, ...TRAININGS_EXTERNAL].map(({ id, categories, themes, ...card }) => (
+          {[...TRAININGS, ...TRAININGS_EXTERNAL].map(({ id, hazards, themes, ...card }) => (
             <div key={id} className="grid-col-12 tablet:grid-col-6 margin-y-1 desktop:margin-y-2">
               <CardDetailed
                 {...makeCardDetailedProps({ ...card, id })}


### PR DESCRIPTION
## Summary

- Renames `Category` type → `Hazard` and `categories` property → `hazards` across the codebase
- Aligns code terminology with Figma design language (UI already labeled these "Hazard")
- 20 files changed: type definition, content helpers, 3 UI pages, 15 content config files

## Test plan

- [ ] TypeScript check passes (`pnpm exec tsc --noEmit`)
- [ ] Training detail page shows hazard tags correctly
- [ ] Data gallery page renders dataset tags correctly
- [ ] Training list page renders without errors