### PR TITLE
feat: Respond and Recover page data visualization

### DIFF
--- a/app/components/ContentBlockRenderer.tsx
+++ b/app/components/ContentBlockRenderer.tsx
@@ -84,7 +84,9 @@ export const ContentBlockRenderer = ({
     case "video":
       return (
         <Section isMultiColumnLayout={isMultiColumnLayout}>
-          {block.title && <h3 className="font-heading-xl margin-bottom-1">{block.title}</h3>}
+          {block.heading && (
+            <ContentHeading heading={block.heading} headingLevel={block.headingLevel} />
+          )}
           {block.src ? (
             <video controls className="width-full display-block">
               <source src={block.src} />
@@ -121,6 +123,7 @@ export const ContentBlockRenderer = ({
           <StacSingleLayerBlock block={block} />
         </Section>
       );
+
     case "stacCompare":
       return (
         <Section isMultiColumnLayout={isMultiColumnLayout}>
@@ -130,6 +133,7 @@ export const ContentBlockRenderer = ({
           <StacCompareBlock block={block} />
         </Section>
       );
+
     case "link":
       return (
         <Section>

--- a/app/recover/page.tsx
+++ b/app/recover/page.tsx
@@ -1,4 +1,5 @@
 import {
+  ContentBlockRenderer,
   PageMasthead,
   Section,
   SectionCardCarousel,
@@ -29,11 +30,10 @@ export default function RecoverPage() {
         sectionHeading={<SectionHeading href="/news-events">Stories of Impact</SectionHeading>}
         cards={typedMap(RECOVER_STORIES, makeCardSimpleProps)}
       />
-      {/* Data Visualization */}
-      <Section>
-        <SectionHeading>Data Visualization</SectionHeading>
-        <p>TODO: Map block</p>
-      </Section>
+      {RECOVER_CONTENT.body.map((block, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static content, never reorders
+        <ContentBlockRenderer key={index} block={block} />
+      ))}
       <SectionCardCarousel
         sectionHeading={<SectionHeading href="/stories">Data Stories</SectionHeading>}
         cards={typedMap(RECOVER_DATASTORIES, makeCardCarouselProps)}

--- a/app/recover/page.tsx
+++ b/app/recover/page.tsx
@@ -1,7 +1,6 @@
 import {
   ContentBlockRenderer,
   PageMasthead,
-  Section,
   SectionCardCarousel,
   SectionCardSimple,
   SectionCardSimpleMosaic,

--- a/app/recover/page.tsx
+++ b/app/recover/page.tsx
@@ -26,7 +26,7 @@ export default function RecoverPage() {
     <>
       <PageMasthead {...makeCardMastHeadProps({ title, subtitle, theme, mastheadImage })} />
       <SectionCardSimpleMosaic
-        sectionHeading={<SectionHeading href="/news-events">News & Events</SectionHeading>}
+        sectionHeading={<SectionHeading href="/news-events">Stories of Impact</SectionHeading>}
         cards={typedMap(RECOVER_STORIES, makeCardSimpleProps)}
       />
       {/* Data Visualization */}

--- a/app/respond/page.tsx
+++ b/app/respond/page.tsx
@@ -29,7 +29,7 @@ export default function RespondPage() {
     <>
       <PageMasthead {...makeCardMastHeadProps({ title, subtitle, theme, mastheadImage })} />
       <SectionCardSimpleMosaic
-        sectionHeading={<SectionHeading href="/news-events">News & Events</SectionHeading>}
+        sectionHeading={<SectionHeading href="/news-events">Stories of Impact</SectionHeading>}
         cards={typedMap(RESPOND_STORIES, makeCardSimpleProps)}
       />
       {/* Data Visualization */}

--- a/app/respond/page.tsx
+++ b/app/respond/page.tsx
@@ -1,7 +1,6 @@
 import {
   ContentBlockRenderer,
   PageMasthead,
-  Section,
   SectionCardCarousel,
   SectionCardSimple,
   SectionCardSimpleMosaic,

--- a/app/respond/page.tsx
+++ b/app/respond/page.tsx
@@ -1,4 +1,5 @@
 import {
+  ContentBlockRenderer,
   PageMasthead,
   Section,
   SectionCardCarousel,
@@ -32,11 +33,10 @@ export default function RespondPage() {
         sectionHeading={<SectionHeading href="/news-events">Stories of Impact</SectionHeading>}
         cards={typedMap(RESPOND_STORIES, makeCardSimpleProps)}
       />
-      {/* Data Visualization */}
-      <Section>
-        <SectionHeading>Data Visualization</SectionHeading>
-        <p>TODO: Map block</p>
-      </Section>
+      {RESPOND_CONTENT.body.map((block, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static content, never reorders
+        <ContentBlockRenderer key={index} block={block} />
+      ))}
       <SectionCardMini
         sectionHeading={<SectionHeading href="/events">Latest Disaster Activations</SectionHeading>}
         cards={typedMap(RESPOND_EVENTS, transformEventToCardMiniProps)}

--- a/app/site-config/theme/theme__recover.ts
+++ b/app/site-config/theme/theme__recover.ts
@@ -1,5 +1,4 @@
 import type {
-  ContentBlock,
   DataStoryContent,
   EventContent,
   NewsContent,

--- a/app/site-config/theme/theme__recover.ts
+++ b/app/site-config/theme/theme__recover.ts
@@ -1,4 +1,5 @@
 import type {
+  ContentBlock,
   DataStoryContent,
   EventContent,
   NewsContent,
@@ -26,6 +27,23 @@ export const RECOVER_CONTENT: ThemeContent = {
   },
   subtitle: "Assess impacts and rebuild stronger.",
   theme: "recover",
+  body: [
+    {
+      type: "stacCompare",
+      heading: "Data Visualization",
+      initialViewState: { longitude: -82.0, latitude: 33.5, zoom: 10 },
+      leftLayerConfig: {
+        type: "raster",
+        collectionId: "blackmarble-june2026-composite",
+        dateRange: { from: "2024-08-01", to: "2024-08-31" },
+      },
+      rightLayerConfig: {
+        type: "raster",
+        collectionId: "blackmarble-hd-daily-june2026",
+        dateRange: { from: "2024-09-28", to: "2024-09-28" },
+      },
+    },
+  ],
 } as const;
 
 // TODO: these would be fetched based on content id

--- a/app/site-config/theme/theme__respond.ts
+++ b/app/site-config/theme/theme__respond.ts
@@ -27,6 +27,23 @@ export const RESPOND_CONTENT: ThemeContent = {
   mastheadImage: { alt: "", src: "/img/theme/respond-masthead.webp" },
   subtitle: "Support real-time decisions with timely insights.",
   theme: "respond",
+  body: [
+    {
+      type: "stacCompare",
+      heading: "Data Visualization",
+      initialViewState: { longitude: -82.0, latitude: 33.5, zoom: 10 },
+      leftLayerConfig: {
+        type: "raster",
+        collectionId: "blackmarble-june2026-composite",
+        dateRange: { from: "2024-08-01", to: "2024-08-31" },
+      },
+      rightLayerConfig: {
+        type: "raster",
+        collectionId: "blackmarble-hd-daily-june2026",
+        dateRange: { from: "2024-09-28", to: "2024-09-28" },
+      },
+    },
+  ],
 } as const;
 
 // TODO: these would be fetched based on content id

--- a/app/site-config/types.ts
+++ b/app/site-config/types.ts
@@ -116,6 +116,7 @@ export type ThemeContent = {
   subtitle: string;
   mastheadImage: MastheadImage;
   theme: Theme;
+  body: ContentBlock[];
 };
 
 type MastheadImage = {

--- a/app/site-config/types.ts
+++ b/app/site-config/types.ts
@@ -23,7 +23,13 @@ export type ContentBlock =
     }
   | { type: "note"; text: string }
   | { type: "slider"; before: { src: string; alt: string }; after: { src: string; alt: string } }
-  | { type: "video"; src: string; title?: string; caption?: string }
+  | {
+      type: "video";
+      src: string;
+      heading?: string;
+      headingLevel?: "h2" | "h3" | "h4";
+      caption?: string;
+    }
   | { type: "image"; src: string; alt: string; width: number; height: number; maxWidth?: string }
   | (StacSingleLayerMapProps &
       GeoConfig & {


### PR DESCRIPTION
* updates Respond and Recover page data visualization (adds placeholder dataset until actual dataset collections are provided)
* updates Respond and Recover page stories of impact title
* updates video content block to use ContentHeading like other blocks