### PR TITLE
feat: Event page

### DIFF
--- a/app/components/OverviewSection.tsx
+++ b/app/components/OverviewSection.tsx
@@ -1,0 +1,51 @@
+import { Link } from "@teamimpact/veda-ui-blocks";
+import type { OverviewSection } from "@/app/site-config/types";
+
+export const OverviewBlock = ({
+  region,
+  startDate,
+  disastersType,
+  overviewLink1,
+  overviewLink2,
+}: OverviewSection) => {
+  const ContainerItem = ({ title, prop }: { title: string; prop: string }) => {
+    return (
+      <div className="grid-col-4">
+        <div className="font-body-md margin-bottom-1 text-semibold">{title}</div>
+        <span className="padding-t-1">{prop}</span>
+      </div>
+    );
+  };
+
+  return (
+    <section className=" margin-bottom-7 grid-container ">
+      <h2 className="font-sans-3xl margin-top-0">Overview</h2>
+      <div
+        className={`grid-row  padding-y-2 border-top border-base-light ${overviewLink1 || overviewLink2 ? "" : "border-bottom"}`}
+      >
+        {region && <ContainerItem title="Region" prop={region} />}
+        {startDate && <ContainerItem title="Start Date" prop={startDate} />}
+
+        {disastersType && <ContainerItem title="Disaster Type" prop={disastersType} />}
+      </div>
+      {overviewLink1 || overviewLink2 ? (
+        <div className="grid-row border-bottom border-base-light padding-bottom-2">
+          {overviewLink1 && (
+            <div className="grid-col-4">
+              <Link className="font-body-md margin-bottom-1 text-semibold" href={overviewLink1}>
+                What the U.S. government is doing
+              </Link>
+            </div>
+          )}
+          {overviewLink2 && (
+            <div className="grid-col-4">
+              <Link className="font-body-md margin-bottom-1 text-semibold" href={overviewLink2}>
+                What DHS and FEMA are doing
+              </Link>
+            </div>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/app/components/OverviewSection.tsx
+++ b/app/components/OverviewSection.tsx
@@ -2,6 +2,13 @@ import { Link } from "@teamimpact/veda-ui-blocks";
 import type { OverviewSection } from "@/app/site-config/types";
 import { Section } from "./Section";
 
+const ContainerItem = ({ title, prop }: { title: string; prop: string }) => (
+  <div className="grid-col-4">
+    <div className="font-body-md margin-bottom-1 text-semibold">{title}</div>
+    <span className="padding-top-1">{prop}</span>
+  </div>
+);
+
 export const OverviewBlock = ({
   region,
   startDate,
@@ -10,20 +17,11 @@ export const OverviewBlock = ({
   overviewLink2,
   isMultiColumnLayout,
 }: OverviewSection & { isMultiColumnLayout?: boolean }) => {
-  const ContainerItem = ({ title, prop }: { title: string; prop: string }) => {
-    return (
-      <div className="grid-col-4">
-        <div className="font-body-md margin-bottom-1 text-semibold">{title}</div>
-        <span className="padding-t-1">{prop}</span>
-      </div>
-    );
-  };
-
   return (
     <Section isMultiColumnLayout={isMultiColumnLayout} className="margin-top-0">
       <h2 className="font-sans-3xl margin-top-0">Overview</h2>
       <div
-        className={`grid-row  padding-y-2 border-top border-base-light ${overviewLink1 || overviewLink2 ? "" : "border-bottom"}`}
+        className={`grid-row padding-y-2 border-top border-base-light ${overviewLink1 || overviewLink2 ? "" : "border-bottom"}`}
       >
         {region && <ContainerItem title="Region" prop={region} />}
         {startDate && <ContainerItem title="Start Date" prop={startDate} />}

--- a/app/components/OverviewSection.tsx
+++ b/app/components/OverviewSection.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@teamimpact/veda-ui-blocks";
 import type { OverviewSection } from "@/app/site-config/types";
+import { Section } from "./Section";
 
 export const OverviewBlock = ({
   region,
@@ -7,7 +8,8 @@ export const OverviewBlock = ({
   disastersType,
   overviewLink1,
   overviewLink2,
-}: OverviewSection) => {
+  isMultiColumnLayout,
+}: OverviewSection & { isMultiColumnLayout?: boolean }) => {
   const ContainerItem = ({ title, prop }: { title: string; prop: string }) => {
     return (
       <div className="grid-col-4">
@@ -18,7 +20,7 @@ export const OverviewBlock = ({
   };
 
   return (
-    <section className=" margin-bottom-7 grid-container ">
+    <Section isMultiColumnLayout={isMultiColumnLayout} className="margin-top-0">
       <h2 className="font-sans-3xl margin-top-0">Overview</h2>
       <div
         className={`grid-row  padding-y-2 border-top border-base-light ${overviewLink1 || overviewLink2 ? "" : "border-bottom"}`}
@@ -46,6 +48,6 @@ export const OverviewBlock = ({
           )}
         </div>
       ) : null}
-    </section>
+    </Section>
   );
 };

--- a/app/components/index.tsx
+++ b/app/components/index.tsx
@@ -2,6 +2,7 @@ export * from "./blocks";
 export { ContentBlockRenderer } from "./ContentBlockRenderer";
 export { HeaderWithCurrentPath } from "./HeaderWithCurrentPath";
 export { ImageComparison } from "./ImageComparison";
+export { OverviewBlock } from "./OverviewSection";
 export { PageMasthead } from "./PageMasthead";
 export { PageStatus } from "./PageStatus";
 export { Section, type SectionProps } from "./Section";

--- a/app/data-gallery/[id]/page.tsx
+++ b/app/data-gallery/[id]/page.tsx
@@ -43,7 +43,7 @@ export default async function DatasetItemPage(props: PageProps<"/data-gallery/[i
       <Section>
         <div className="grid-row grid-gap">
           <div className="grid-col-12 desktop:grid-col-3">
-            {/* TO DO: DatasetSidebar needs to be updated to a generic sidebare component */}
+            {/* TO DO: DatasetSidebar needs to be updated to a generic sidebar component */}
             <DatasetSidebar themes={themes} categories={categories} relatedContent={relatedItems} />
           </div>
           <div className="grid-col-12 desktop:grid-col-9">

--- a/app/data-gallery/[id]/page.tsx
+++ b/app/data-gallery/[id]/page.tsx
@@ -43,6 +43,7 @@ export default async function DatasetItemPage(props: PageProps<"/data-gallery/[i
       <Section>
         <div className="grid-row grid-gap">
           <div className="grid-col-12 desktop:grid-col-3">
+            {/* TO DO: DatasetSidebar needs to be updated to a generic sidebare component */}
             <DatasetSidebar themes={themes} categories={categories} relatedContent={relatedItems} />
           </div>
           <div className="grid-col-12 desktop:grid-col-9">

--- a/app/news-events/[id]/page.tsx
+++ b/app/news-events/[id]/page.tsx
@@ -1,30 +1,41 @@
 import { notFound } from "next/navigation";
-import { PageMasthead, PageStatus, Section } from "@/app/components/";
+import { ContentBlockRenderer, OverviewBlock, PageMasthead, Section } from "@/app/components";
+import { DatasetSidebar } from "@/app/data-gallery/[id]/DatasetSidebar";
 import { makeCardMastHeadProps } from "@/app/site-config/content.helpers";
-import { DATASTORIES } from "@/app/site-config/datastory";
 import { EVENTS } from "@/app/site-config/event";
-import { NEWS } from "@/app/site-config/news";
-import { STORIES } from "@/app/site-config/story";
 
-export default async function NewsEventsItemPage(props: PageProps<"/news-events/[id]">) {
+export default async function EventItemPage(props: PageProps<"/news-events/[id]">) {
   const { id } = await props.params;
 
-  const contentItem = [...STORIES, ...DATASTORIES, ...NEWS, ...EVENTS].find((s) => s.id === id);
+  const event = EVENTS.find((t) => t.id === id);
 
-  if (!contentItem) notFound();
-
-  const { mastheadImage, title } = contentItem;
+  if (!event) notFound();
+  //TO DO: this will need to account for inpage navigation once implements
+  const showSidebar = event.themes.length > 0 || event.categories.length > 0;
+  const { title, description, mastheadImage, themes, categories, body, date } = event;
 
   return (
     <>
-      <PageMasthead {...makeCardMastHeadProps({ mastheadImage, title })} />
+      {/* Hero */}
+      <PageMasthead {...makeCardMastHeadProps({ mastheadImage, title, description, date })} />
 
-      <Section className="margin-top-4 margin-bottom-0">
-        <PageStatus
-          label={`News, Data Story, or Story Item: ${id}`}
-          heading="Under development"
-          description="The page you're looking for is under development."
-        />
+      {/* Content */}
+      <Section>
+        <div className="grid-row grid-gap">
+          {/* Sidebar */}
+          {/* TO DO: DatasetSidebar will need to be elevated to a general sidebar component this will also be placement for the inpage navigation once ready*/}
+          <div className="grid-col-12 desktop:grid-col-3">
+            <DatasetSidebar themes={themes} categories={categories} />
+          </div>
+          {/* Main content */}
+          <div className={` ${showSidebar ? "grid-col-9" : "grid-col-12"}`}>
+            <OverviewBlock {...event.overview} />
+            {body?.map((block, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: static content blocks, never reorder
+              <ContentBlockRenderer key={i} block={block} isMultiColumnLayout={showSidebar} />
+            ))}
+          </div>
+        </div>
       </Section>
     </>
   );

--- a/app/news-events/[id]/page.tsx
+++ b/app/news-events/[id]/page.tsx
@@ -29,7 +29,7 @@ export default async function EventItemPage(props: PageProps<"/news-events/[id]"
           </div>
           {/* Main content */}
           <div className={` ${showSidebar ? "grid-col-9" : "grid-col-12"}`}>
-            <OverviewBlock {...event.overview} />
+            <OverviewBlock {...event.overview} isMultiColumnLayout={showSidebar} />
             {body?.map((block, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: static content blocks, never reorder
               <ContentBlockRenderer key={i} block={block} isMultiColumnLayout={showSidebar} />

--- a/app/news-events/[id]/page.tsx
+++ b/app/news-events/[id]/page.tsx
@@ -24,12 +24,16 @@ export default async function EventItemPage(props: PageProps<"/news-events/[id]"
         <div className="grid-row grid-gap">
           {/* Sidebar */}
           {/* TO DO: DatasetSidebar will need to be elevated to a general sidebar component this will also be placement for the inpage navigation once ready*/}
-          <div className="grid-col-12 desktop:grid-col-3">
-            <DatasetSidebar themes={themes} categories={categories} />
-          </div>
+          {showSidebar && (
+            <div className="grid-col-12 desktop:grid-col-3">
+              <DatasetSidebar themes={themes} categories={categories} />
+            </div>
+          )}
           {/* Main content */}
-          <div className={` ${showSidebar ? "grid-col-9" : "grid-col-12"}`}>
-            <OverviewBlock {...event.overview} isMultiColumnLayout={showSidebar} />
+          <div className={`grid-col-12${showSidebar ? " desktop:grid-col-9" : ""}`}>
+            {event.overview && (
+              <OverviewBlock {...event.overview} isMultiColumnLayout={showSidebar} />
+            )}
             {body?.map((block, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: static content blocks, never reorder
               <ContentBlockRenderer key={i} block={block} isMultiColumnLayout={showSidebar} />

--- a/app/site-config/content.helpers.tsx
+++ b/app/site-config/content.helpers.tsx
@@ -71,12 +71,14 @@ type CardMastheadPropsArgs = Omit<CardProps, "title" | "image" | "colorMode" | "
   };
   title?: string;
   theme?: Theme;
+  date?: string;
 };
 
 export const makeCardMastHeadProps = ({
   mastheadImage,
   title,
   theme,
+  date,
   ...rest
 }: CardMastheadPropsArgs): CardProps => ({
   image: <Image {...mastheadImage} sizes="100vw" fill preload={true} />,
@@ -93,6 +95,11 @@ export const makeCardMastHeadProps = ({
     : {}),
   colorMode: "brand",
   isMastHead: true,
+  tag: date ? (
+    <Tag color="primary-lighter" textColor="primary-dark">
+      Updated: {formattedDate(date)}
+    </Tag>
+  ) : undefined,
   ...rest,
 });
 
@@ -267,3 +274,10 @@ export const makeCardCarouselProps = ({
   colorMode: "dark",
   ...rest,
 });
+
+export const formattedDate = (date: string) =>
+  new Date(date).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });


### PR DESCRIPTION
## Adding Event page
Implement event detail experience on `/news-events/[id]` with overview + body rendering

## Direct Link to page

https://deploy-preview-154--dlp-disasters-portal.netlify.app/news-events/us-winter-storm-jan-2026

## Summary
This PR replaces the placeholder state on the news/events detail route with a real event page implementation.  
It introduces an overview section component, renders event body blocks, and updates masthead helpers to support date tagging.

## What changed
- Converted the detail route implementation to be event-specific:
  - Looks up content from `EVENTS` only.
  - Returns `notFound()` when no matching event exists.
- Replaced the under-development placeholder with full page content:
  - Hero masthead (title, description, image, date).
  - Sidebar (themes/categories) using the existing sidebar pattern.
  - Overview section.
  - Content blocks rendered in sequence.
- Added a new reusable `OverviewBlock` component:
  - Displays region, start date, and disaster type.
  - Optionally displays two overview links.
  - Supports `isMultiColumnLayout` for responsive layout behavior when sidebar is present.
- Enhanced masthead prop helper to support and format date:
  - Adds a tag: `Updated: <formatted date>` when date is provided.
  - Added a small date formatter utility.
- Exported the new overview component from the shared components barrel.

## Why
- Moves the event detail route from placeholder UX to usable production content.
- Establishes a consistent structure for event pages (hero + sidebar + overview + blocks).
- Keeps layout adaptable depending on whether sidebar metadata exists.

## Notes / Known follow-ups
- Sidebar currently reuses the dataset sidebar implementation as a temporary step.
- Follow-up planned: promote sidebar to a generalized shared component and add in-page navigation support.