### PR TITLE
feat: set external Respond data story links

### DIFF
--- a/app/site-config/datastory/datastory__hurricane-helene-september-2024.ts
+++ b/app/site-config/datastory/datastory__hurricane-helene-september-2024.ts
@@ -4,6 +4,7 @@ export const DATASTORY__HURRICANE_HELENE_SEPTEMBER_2024: DataStoryContent = {
   id: "hurricane-helene-september-2024",
   contentType: "datastory",
   title: "Hurricane Helene - September 2024",
+  url: "https://deploy-preview-205--disasters-portal.netlify.app/events/hurricane-helene-2024",
   thumbnailImage: {
     src: "/img/datastory/hurricane-helene-september-2024.webp",
     alt: "Nighttime satellite image of Hurricane Helene in 2024 captured by NOAA-20",

--- a/app/site-config/datastory/datastory__hurricane-milton-october-2024.ts
+++ b/app/site-config/datastory/datastory__hurricane-milton-october-2024.ts
@@ -4,6 +4,7 @@ export const DATASTORY__HURRICANE_MILTON_OCTOBER_2024: DataStoryContent = {
   id: "hurricane-milton-october-2024",
   contentType: "datastory",
   title: "Hurricane Milton - October 2024",
+  url: "https://deploy-preview-205--disasters-portal.netlify.app/events/hurricane-milton-2024",
   thumbnailImage: {
     src: "/img/datastory/hurricane-milton-october-2024.webp",
     alt: "Hurricane Milton in 2024 showing storm system over ocean with visible eye of the storm",

--- a/app/site-config/types.ts
+++ b/app/site-config/types.ts
@@ -122,6 +122,7 @@ export type MinimumCardContent = {
   id: string;
   contentType: ContentType;
   title: string;
+  url?: string;
   thumbnailImage: {
     src: string;
     alt: string;


### PR DESCRIPTION
Added support for optional per-card URL overrides and pointed the two Respond data story cards to the provided external event pages.

## Changes 
- Added an optional url field to shared card content typing
- Set Hurricane Helene data story card to the provided external events URL
- Set Hurricane Milton data story card to the provided external events URL