### PR TITLE
fix: update actual text for SEO, was not fixed last time

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { HeaderWithCurrentPath } from "@/app/components";
 import { MOCK_FOOTER_PROPS } from "./site-config/footer";
 
 export const metadata: Metadata = {
-  title: "Disasters portal",
+  title: "NASA Disasters PORTAL",
   description: "NASA Disasters PORTAL",
 };
 


### PR DESCRIPTION
Previous fix only updated the description. I thought initially it was an Amplify cache issue, but I realized I changed the wrong part. This completes part of fix from #181 .