### PR TITLE
fix: update text and moved header to single line

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -21,10 +21,8 @@ export default function AboutPage() {
                   className="display-block"
                 />
               </div>
-              <h1 className="text-primary-dark">
-                <span className="display-block">About the</span>
-                <span className="display-block">NASA Disasters</span>
-                <span className="display-block">Program</span>
+              <h1 className="text-primary-dark font-heading-3xl margin-0">
+                About the NASA Disasters Program
               </h1>
             </div>
           </div>

--- a/app/site-config/about/about__page.tsx
+++ b/app/site-config/about/about__page.tsx
@@ -39,7 +39,7 @@ export const ABOUT_PAGE_BODY: AboutPageBody = {
     },
     {
       type: "text",
-      heading: "Connect with us",
+      heading: "Connect With Us",
       headingLevel: "h2",
       paragraphs: [
         <Fragment key="hq-em-disasters@mail.nasa.gov">


### PR DESCRIPTION
Addresses #183 

- moved the header title to single line
- ensured that it is larger than the other headers
- capitalized Us in the Connect with Us