### PR TITLE
fix: removed label, updates text per recommendations

### DIFF
--- a/app/components/PageStatus.tsx
+++ b/app/components/PageStatus.tsx
@@ -16,7 +16,7 @@ export function PageStatus({ label, heading, description }: PageStatusProps) {
       </h1>
       {description && <p className="font-body-md text-base margin-bottom-6">{description}</p>}
       <Link href="/" className="usa-button">
-        Return to home page
+        Return to Home Page
       </Link>
     </div>
   );

--- a/app/data-gallery/[id]/page.tsx
+++ b/app/data-gallery/[id]/page.tsx
@@ -52,8 +52,7 @@ export default async function DatasetItemPage(props: PageProps<"/data-gallery/[i
       {/* Placeholder content only */}
       {!body && (
         <PageStatus
-          label={`Dataset Item: ${id}`}
-          heading="Under development"
+          heading="Under Development"
           description="The page you're looking for is under development."
         />
       )}

--- a/app/data-processing/page.tsx
+++ b/app/data-processing/page.tsx
@@ -3,8 +3,7 @@ import { PageStatus } from "@/app/components/";
 export default function DataProcessingPage() {
   return (
     <PageStatus
-      label="Data Processing"
-      heading="Under development"
+      heading="Under Development"
       description="The page you're looking for is under development."
     />
   );

--- a/app/news-events/[id]/page.tsx
+++ b/app/news-events/[id]/page.tsx
@@ -36,8 +36,7 @@ export default async function NewsEventsItemPage(props: PageProps<"/news-events/
       {/* Placeholder content only */}
       {!body && (
         <PageStatus
-          label={`Story, Datastory, or News Item: ${id}`}
-          heading="Under development"
+          heading="Under Development"
           description="The page you're looking for is under development."
         />
       )}

--- a/app/news-events/[id]/page_event.tsx
+++ b/app/news-events/[id]/page_event.tsx
@@ -15,7 +15,7 @@ import type { EventContent } from "@/app/site-config/types";
 export default async function EventItemPage(contentItem: EventContent) {
   // TO DO: this will need to account for inpage navigation once implements
 
-  const { id, contentType, themes, categories, body } = contentItem;
+  const { contentType, themes, categories, body } = contentItem;
 
   return (
     <>
@@ -25,8 +25,7 @@ export default async function EventItemPage(contentItem: EventContent) {
       {/* Placeholder content only */}
       {!body && (
         <PageStatus
-          label={`Event Item: ${id}`}
-          heading="Under development"
+          heading="Under Development"
           description="The page you're looking for is under development."
         />
       )}

--- a/app/prepare/page.tsx
+++ b/app/prepare/page.tsx
@@ -3,8 +3,7 @@ import { PageStatus } from "@/app/components/";
 export default function PreparePage() {
   return (
     <PageStatus
-      label="Prepare"
-      heading="Under development"
+      heading="Under Development"
       description="The page you're looking for is under development."
     />
   );

--- a/app/resilience/page.tsx
+++ b/app/resilience/page.tsx
@@ -3,8 +3,7 @@ import { PageStatus } from "@/app/components/";
 export default function ResiliencePage() {
   return (
     <PageStatus
-      label="Build Resilience"
-      heading="Under development"
+      heading="Under Development"
       description="The page you're looking for is under development."
     />
   );

--- a/app/training/[id]/page.tsx
+++ b/app/training/[id]/page.tsx
@@ -40,8 +40,7 @@ export default async function TrainingItemPage(props: PageProps<"/training/[id]"
       {/* Placeholder content only */}
       {!training.body && (
         <PageStatus
-          label={`Training Item: ${id}`}
-          heading="Under development"
+          heading="Under Development"
           description="The page you're looking for is under development."
         />
       )}


### PR DESCRIPTION
## Changes

- **Component (`app/components/PageStatus.tsx`)**
  - Capitalized CTA button: `Return to home page` → `Return to Home Page`

- **Standalone "Under Development" pages**
  - Removed page-name `label` prop (no more "Prepare" / "Data Processing" / "Build Resilience" stacked above the heading)
  - Capitalized heading: `Under development` → `Under Development`
  - Affects: `app/prepare/page.tsx`, `app/data-processing/page.tsx`, `app/resilience/page.tsx`

- **Conditional placeholders inside detail pages** (shown when content `body` is missing)
  - Removed slug-based `label` prop (e.g. dropped `Dataset Item: ${id}`, `Training Item: ${id}`, `Story, Datastory, or News Item: ${id}`, `Event Item: ${id}`)
  - Capitalized heading: `Under development` → `Under Development`
  - Affects: `app/data-gallery/[id]/page.tsx`, `app/training/[id]/page.tsx`, `app/news-events/[id]/page.tsx`, `app/news-events/[id]/page_event.tsx`

- **Cleanup**
  - `app/news-events/[id]/page_event.tsx`: removed `id` from the `contentItem` destructure (it was only used by the now-removed label; lint flagged it as unused)


This also fixes the other changes requested by Disasters including:

<img width="491" height="141" alt="image" src="https://github.com/user-attachments/assets/459717f5-e411-4a9d-aee3-6ceaac4b4e05" />
<img width="478" height="178" alt="image" src="https://github.com/user-attachments/assets/dca86912-fd59-4398-85e6-683140f27401" />
<img width="443" height="182" alt="image" src="https://github.com/user-attachments/assets/cc6ddab4-0625-42bf-abce-4254ea544776" />
<img width="491" height="67" alt="image" src="https://github.com/user-attachments/assets/215f0a03-b06d-4af1-a2df-9f50937b245a" />

