### PR TITLE
fix: remove placeholder page sidebar per recommendations

### DIFF
--- a/app/components/PageSidebar.tsx
+++ b/app/components/PageSidebar.tsx
@@ -80,9 +80,6 @@ export function PageSidebar({
           </div>
         )
       }
-      <div className="bg-base-lightest padding-4 margin-bottom-4">
-        Placeholder for in page navigation
-      </div>
     </aside>
   );
 }


### PR DESCRIPTION
Per recommendations from Disasters, any page that has a placeholder sidebar nav should not have it. This fix removes the placeholder from all pages that have it.

This fixes items for: 

<img width="447" height="48" alt="image" src="https://github.com/user-attachments/assets/a4a1c9cc-9ffe-4d11-a9e2-ede9731a702f" />
<img width="425" height="47" alt="image" src="https://github.com/user-attachments/assets/58e713e6-b0dc-486a-9a8a-e1b96bec03f2" />
<img width="461" height="213" alt="image" src="https://github.com/user-attachments/assets/87af7fd0-d2a0-4eca-a1d4-4f7856067d89" />


Addresses #209 