### PR TITLE
fix: update route for resilience to match other ones to create a Under Development page

### DIFF
--- a/app/site-config/home/home-card-masthead.tsx
+++ b/app/site-config/home/home-card-masthead.tsx
@@ -22,7 +22,7 @@ const MOCK_FEATURE_CTACARDS_PROPS = [
   {
     title: "Build Resilience",
     description: "Safeguard communities for enduring impact",
-    url: "/build-resilience",
+    url: "/resilience",
     accentColor: "#1d9950",
   },
 ];


### PR DESCRIPTION
Fixes this 
<img width="481" height="96" alt="image" src="https://github.com/user-attachments/assets/940ab89b-b92f-4bd6-bd8d-bb4779e3abc3" />


Currently there was a routing issue which prevented the `Under Development` page to show properly. It had this 404 error  before

<img width="1134" height="401" alt="image" src="https://github.com/user-attachments/assets/65f57487-d73f-4c14-9e41-575cbc7d5428" />
