### PR TITLE
fix: Update Data Stories Section 

### DIFF
--- a/app/site-config/content.helpers.tsx
+++ b/app/site-config/content.helpers.tsx
@@ -110,7 +110,7 @@ export const makeCardDetailedProps = ({
   // TODO: need to add isExternal handling to all cards in veda-ui-blocks
   callToAction: {
     href: url ? url : `${CONTENT_TYPES[contentType].route}/${id}`,
-    label: `view ${CONTENT_TYPES[contentType].label}`,
+    label: `View ${CONTENT_TYPES[contentType].label}`,
   },
   ...rest,
 });
@@ -130,7 +130,7 @@ export const makeCardDetailedImageLeftProps = ({
   // TODO: need to add isExternal handling to all cards in veda-ui-blocks
   callToAction: {
     href: url ? url : `${CONTENT_TYPES[contentType].route}/${id}`,
-    label: `view ${CONTENT_TYPES[contentType].label}`,
+    label: `View ${CONTENT_TYPES[contentType].label}`,
   },
   ...rest,
 });
@@ -241,7 +241,7 @@ export const makeCardCarouselProps = ({
   tag: makeContentTypeTag(contentType),
   callToAction: {
     href: url ? url : `${CONTENT_TYPES[contentType].route}/${id}`,
-    label: `view ${CONTENT_TYPES[contentType].label}`,
+    label: `View ${CONTENT_TYPES[contentType].label}`,
   },
   imagePosition: "cover",
   colorMode: "dark",

--- a/app/site-config/datastory/datastory__hurricane-helene-september-2024.ts
+++ b/app/site-config/datastory/datastory__hurricane-helene-september-2024.ts
@@ -14,4 +14,5 @@ export const DATASTORY__HURRICANE_HELENE_SEPTEMBER_2024: DataStoryContent = {
     src: "/img/datastory/hurricane-helene-september-2024.webp",
     alt: "Nighttime satellite image of Hurricane Helene in 2024 captured by NOAA-20",
   },
+  url: "https://deploy-preview-205--disasters-portal.netlify.app/events/hurricane-helene-2024",
 };

--- a/app/site-config/datastory/datastory__hurricane-milton-october-2024.ts
+++ b/app/site-config/datastory/datastory__hurricane-milton-october-2024.ts
@@ -14,4 +14,5 @@ export const DATASTORY__HURRICANE_MILTON_OCTOBER_2024: DataStoryContent = {
     src: "/img/datastory/hurricane-milton-october-2024.webp",
     alt: "Hurricane Milton in 2024 showing storm system over ocean with visible eye of the storm",
   },
+  url: "https://deploy-preview-205--disasters-portal.netlify.app/events/hurricane-milton-2024",
 };

--- a/app/site-config/types.ts
+++ b/app/site-config/types.ts
@@ -12,7 +12,7 @@ export const CONTENT_TYPES: Record<ContentType, { route: AppRoutes; label: strin
   event: { route: "/news-events", label: "event" },
   news: { route: "/news-events", label: "news" },
   story: { route: "/news-events", label: "story" },
-  datastory: { route: "/news-events", label: "data story" },
+  datastory: { route: "/news-events", label: "Data Story" },
   training: { route: "/training", label: "training" },
 };
 
@@ -168,6 +168,7 @@ export type DataStoryContent = Omit<MinimumCardContent, "contentType"> & {
   contentType: "datastory";
   mastheadImage: MastheadImage;
   body?: ContentBlock[];
+  url?: string;
 };
 
 export type EventContent = Omit<MinimumCardContent, "contentType"> & {


### PR DESCRIPTION
Issue number: #196 

Changes
- Capitalized "view" to "View" in call-to-action button label across all card helpers.
- Added `url?` field to `DataStoryContent` type.
- Added external URLs for Hurricane Helene and Hurricane Milton data story cards.

