### PR TITLE
fix: Remove official government banner from site layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Banner, Footer } from "@teamimpact/veda-ui-blocks";
+import { Footer } from "@teamimpact/veda-ui-blocks";
 import type { Metadata } from "next";
 import "@teamimpact/veda-ui-blocks/disasters.css";
 
@@ -24,7 +24,6 @@ export default function RootLayout({
           gridTemplateRows: "auto auto 1fr auto" /* banner, header, main, footer */,
         }}
       >
-        <Banner />
         <HeaderWithCurrentPath />
         <main>{children}</main>
         <Footer {...MOCK_FOOTER_PROPS} />


### PR DESCRIPTION
Issue number: #228 
Summary:
Removes the "An official website of the United States government" gray banner 
that appeared at the top of every page on the site.

Changes

in `app/layout.tsx`

**Line 1 — Removed `Banner` from import:**
```diff
- import { Banner, Footer } from "@teamimpact/veda-ui-blocks";
+ import { Footer } from "@teamimpact/veda-ui-blocks";
```

**Line 24 — Removed `<Banner />` component from layout:**
```diff
- <Banner />
  <HeaderWithCurrentPath />
```
Notes
- Removing the component and its unused import is the complete fix


