### PR TITLE
fix: update Image Use Policy link in bottom nav

### DIFF
--- a/app/site-config/footer.tsx
+++ b/app/site-config/footer.tsx
@@ -9,9 +9,13 @@ const primaryNavItems: FooterProps["primaryNavItems"] = [
 ];
 
 const secondaryNavItems: FooterProps["secondaryNavItems"] = [
-  { label: "Image Use Policy", href: "https://www.nasa.gov/accessibility/", isExternal: true },
   {
-    label: "Privacy policy",
+    label: "Image Use Policy",
+    href: "https://www.nasa.gov/nasa-brand-center/images-and-media/",
+    isExternal: true,
+  },
+  {
+    label: "Privacy Policy",
     href: "https://www.nasa.gov/nasa-web-privacy-policy-and-important-notices/",
     isExternal: true,
   },


### PR DESCRIPTION
Issue Number: #232 

Summary:
Updates the "Image Use Policy" link in the site footer to https://www.nasa.gov/nasa-brand-center/images-and-media// .

Changes:

##`app/site-config/footer.tsx`

**Line 12 — Updated href for Image Use Policy:**
```diff
- href: "https://www.nasa.gov/accessibility/",
+ href: "https://www.nasa.gov/nasa-brand-center/images-and-media/",
```

