### PR TITLE
fix: remove hardcoded deploy preview URLs from data story links

### DIFF
--- a/app/site-config/datastory/datastory__hurricane-helene-september-2024.ts
+++ b/app/site-config/datastory/datastory__hurricane-helene-september-2024.ts
@@ -14,5 +14,4 @@ export const DATASTORY__HURRICANE_HELENE_SEPTEMBER_2024: DataStoryContent = {
     src: "/img/datastory/hurricane-helene-september-2024.webp",
     alt: "Nighttime satellite image of Hurricane Helene in 2024 captured by NOAA-20",
   },
-  url: "https://deploy-preview-205--disasters-portal.netlify.app/events/hurricane-helene-2024",
 };

--- a/app/site-config/datastory/datastory__hurricane-milton-october-2024.ts
+++ b/app/site-config/datastory/datastory__hurricane-milton-october-2024.ts
@@ -14,5 +14,4 @@ export const DATASTORY__HURRICANE_MILTON_OCTOBER_2024: DataStoryContent = {
     src: "/img/datastory/hurricane-milton-october-2024.webp",
     alt: "Hurricane Milton in 2024 showing storm system over ocean with visible eye of the storm",
   },
-  url: "https://deploy-preview-205--disasters-portal.netlify.app/events/hurricane-milton-2024",
 };


### PR DESCRIPTION
While browsing the deployed website I noticed the [data stories](https://disasters.openveda.cloud/news-events) were point to a deploy preview for PR #205, with hardcoded urls.

This was introduced in #230.

This PR remove those hardcoded URLs, letting the stories to use internal links.

To review, the /news-events in the deploy preview for this PR and confirm the URLS are not pointing to old PRs.

cc @kyle-lesinger @bhawana11 