### PR TITLE
feat: add themes and categories to Sentinel-2 datasets

### DIFF
--- a/app/site-config/dataset/dataset__sentinel-2-color-infrared.ts
+++ b/app/site-config/dataset/dataset__sentinel-2-color-infrared.ts
@@ -14,8 +14,16 @@ export const DATASET__SENTINEL_2_COLOR_INFRARED: DatasetContent = {
     src: "/img/dataset/sentinel-2-color-infrared.webp",
     alt: "Sentinel-2 Color Infrared imagery example",
   },
-  themes: [],
-  categories: [],
+  themes: ["respond", "build", "prepare", "recover"],
+  categories: [
+    "severewx",
+    "fire",
+    "heat",
+    "flood",
+    "tropical cyclone",
+    "earthquake",
+    "winter weather",
+  ],
   relatedContent: ["sentinel-2-true-color", "sentinel-2-swir"],
   body: [
     {

--- a/app/site-config/dataset/dataset__sentinel-2-swir.ts
+++ b/app/site-config/dataset/dataset__sentinel-2-swir.ts
@@ -13,8 +13,16 @@ export const DATASET__SENTINEL_2_SWIR: DatasetContent = {
     src: "/img/dataset/sentinel-2-swir.webp",
     alt: "Sentinel-2 Shortwave Infrared imagery example",
   },
-  themes: [],
-  categories: [],
+  themes: ["respond", "build", "prepare", "recover"],
+  categories: [
+    "severewx",
+    "fire",
+    "heat",
+    "flood",
+    "tropical cyclone",
+    "earthquake",
+    "winter weather",
+  ],
   relatedContent: ["sentinel-2-true-color", "sentinel-2-color-infrared"],
   body: [
     {

--- a/app/site-config/dataset/dataset__sentinel-2-true-color.ts
+++ b/app/site-config/dataset/dataset__sentinel-2-true-color.ts
@@ -14,8 +14,16 @@ export const DATASET__SENTINEL_2_TRUE_COLOR: DatasetContent = {
     src: "/img/dataset/sentinel-2-true-color.webp",
     alt: "Sentinel-2 True Color imagery example",
   },
-  themes: [],
-  categories: [],
+  themes: ["respond", "build", "prepare", "recover"],
+  categories: [
+    "severewx",
+    "fire",
+    "heat",
+    "flood",
+    "tropical cyclone",
+    "earthquake",
+    "winter weather",
+  ],
   relatedContent: ["sentinel-2-color-infrared", "sentinel-2-swir"],
   body: [
     {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "dev": "next dev --port 3006",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 3006",
     "build": "next build",
     "start": "next start",
     "lint": "biome check .",


### PR DESCRIPTION
Add all themes and categories to Sentinel-2 datasets (color-infrared, swir, true-color).

**Deploy preview:** Visit /data-gallery to see tags displayed on dataset cards

Closes #168