### PR TITLE
fix: update the text default for training and News pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Footer } from "@teamimpact/veda-ui-blocks";
 import type { Metadata } from "next";
 import "@teamimpact/veda-ui-blocks/disasters.css";
+import "@/app/styles/globals.css";
 
 import { HeaderWithCurrentPath } from "@/app/components";
 import { MOCK_FOOTER_PROPS } from "./site-config/footer";

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -1,0 +1,4 @@
+/* Match CardDetailed description size to body text (1rem / 16px) instead of vendor default 0.75rem. */
+.blocks-card-detailed__description {
+  font-size: 1rem;
+}


### PR DESCRIPTION
Addresses this:

<img width="992" height="161" alt="image" src="https://github.com/user-attachments/assets/7a4930d2-e0e9-47c0-8d65-8f8014fae160" />
