### PR TITLE
fix: Typhoon sinlaku content update 

### DIFF
--- a/app/site-config/event/event__typhoon-sinlaku-2026.tsx
+++ b/app/site-config/event/event__typhoon-sinlaku-2026.tsx
@@ -22,8 +22,6 @@ export const EVENT__TYPHOON_SINLAKU_2026: EventContent = {
   body: [
     {
       type: "text",
-      heading: "Typhoon Sinlaku",
-      headingLevel: "h2",
       paragraphs: [
         "NASA supported U.S. response agencies when Typhoon Sinlaku struck the Northern Mariana Islands and Guam.",
         "Typhoon Sinlaku brought high winds and heavy rainfall to the Northern Mariana Islands and Guam, causing widespread power blackouts, flooding, and extensive damage to homes and infrastructure.",

--- a/app/site-config/event/event__typhoon-sinlaku-2026.tsx
+++ b/app/site-config/event/event__typhoon-sinlaku-2026.tsx
@@ -23,7 +23,6 @@ export const EVENT__TYPHOON_SINLAKU_2026: EventContent = {
     {
       type: "text",
       paragraphs: [
-        "NASA supported U.S. response agencies when Typhoon Sinlaku struck the Northern Mariana Islands and Guam.",
         "Typhoon Sinlaku brought high winds and heavy rainfall to the Northern Mariana Islands and Guam, causing widespread power blackouts, flooding, and extensive damage to homes and infrastructure.",
         <Fragment key="Typhoon Sinlaku paragraph 2">
           In coordination with FEMA and other federal partners, the NASA Disasters Program worked


### PR DESCRIPTION
* remove body content title. (duplicative of masthead)
* remove the first sentence (intended to be a masthead caption)

https://docs.google.com/document/d/1RIu2hNyzEn-UXwQSKWr4D2x40pircS9bQi0i51gb_QU/edit?userstoinvite=acb0068@uah.edu&sharingaction=manageaccess&role=writer&tab=t.0