### PR TITLE
fix: remove duplicate Typhoon Sinlaku heading and intro sentence

### DIFF
--- a/app/site-config/event/event__typhoon-sinlaku-2026.tsx
+++ b/app/site-config/event/event__typhoon-sinlaku-2026.tsx
@@ -22,10 +22,8 @@ export const EVENT__TYPHOON_SINLAKU_2026: EventContent = {
   body: [
     {
       type: "text",
-      heading: "Typhoon Sinlaku",
       headingLevel: "h2",
       paragraphs: [
-        "NASA supported U.S. response agencies when Typhoon Sinlaku struck the Northern Mariana Islands and Guam.",
         "Typhoon Sinlaku brought high winds and heavy rainfall to the Northern Mariana Islands and Guam, causing widespread power blackouts, flooding, and extensive damage to homes and infrastructure.",
         <Fragment key="Typhoon Sinlaku paragraph 2">
           In coordination with FEMA and other federal partners, the NASA Disasters Program worked


### PR DESCRIPTION
Issue Number:  #245

Summary:
Removes duplicate content from the Typhoon Sinlaku April 2026 event page 
as flagged in the issue.

 Changes

##`app/site-config/event/event__typhoon-sinlaku-2026.tsx`

**Removed duplicate heading:**
```diff
- heading: "Typhoon Sinlaku",
  headingLevel: "h2",
```

**Removed intro sentence from body paragraphs:**
```diff
- "NASA supported U.S. response agencies when Typhoon Sinlaku struck the Northern Mariana Islands and Guam.",
  "Typhoon Sinlaku brought high winds and heavy rainfall...
```