### PR TITLE
fix: Disable Data Visualization link; route to Under Development page

### DIFF
--- a/app/data-visualization/page.tsx
+++ b/app/data-visualization/page.tsx
@@ -1,0 +1,10 @@
+import { PageStatus } from "@/app/components/";
+
+export default function DataVisualizationPage() {
+  return (
+    <PageStatus
+      heading="Under Development"
+      description="The page you're looking for is under development."
+    />
+  );
+}

--- a/app/site-config/header.tsx
+++ b/app/site-config/header.tsx
@@ -18,11 +18,7 @@ const MOCK_NAV_ITEM_WITH_DROPDOWN_2 = [
     label: "Explore Data",
     subItems: [
       { label: "Data Gallery", href: "/data-gallery" },
-      {
-        label: "Data Visualization",
-        href: "https://data-visualization.disasters.openveda.cloud/?datasets=%5B%7B%22id%22%3A%22rgb%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%7D%7D%2C%7B%22id%22%3A%22gaia-january2025-composite-total%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%7D%7D%5D&taxonomy=%7B%7D&search=&date=2025-01-11T06%3A00%3A00.000Z",
-        isExternal: true,
-      },
+      { label: "Data Visualization", href: "/data-visualization" },
       { label: "Data Processing", href: "/data-processing" },
     ],
   },


### PR DESCRIPTION
## Summary

The **Data Visualization** nav item (Explore Data dropdown) linked out to an external `data-visualization.disasters.openveda.cloud/...` URL. This disables that link so it no longer navigates off-site.

## Changes

- Added a `/data-visualization` route that renders the standard **Under Development** `PageStatus` screen (same pattern as `/prepare`).
- Repointed the header nav item from the external URL to `/data-visualization` (removed `isExternal: true`), so clicking it stays in-app and lands on the Under Development screen.

## Verification

- `npm run typecheck` and `biome check` pass (also enforced by the pre-commit hook).
- In the browser: the nav link's `href` is now `/data-visualization` (no `target="_blank"`), and visiting it shows the "Under Development" screen.